### PR TITLE
Added raw json displaying to core datatable component

### DIFF
--- a/components/core/Datatable.jsx
+++ b/components/core/Datatable.jsx
@@ -34,71 +34,77 @@ const baseStyles = {
 
 
 class Datatable extends PureComponent {
-  
+
   constructor (props) {
     super(props);
-    
+
     this.updateQuery = this.updateQuery.bind(this);
-    
+
     this.state = {
       query: '',
     };
   }
-  
+
   updateQuery (value) {
     this.setState({
       query: value,
     });
   }
-  
+
   render () {
-    
-    const {
-      className,
-      collection,
-      options,
-      showSearch,
-      showNew,
-      currentUser,
-      classes,
-    } = this.props;
-    
-    const listOptions = {
-      collection: collection,
-      ...options,
-    };
-    
-    const DatatableWithList = withList(listOptions)(Components.DatatableContents);
-    
-    return (
-      <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
-        className)}>
-        
-        {
-          showSearch &&
-          
-          <Components.SearchInput value={this.state.query}
-                                  updateQuery={this.updateQuery}
+    if (this.props.data) {
+
+      return <Components.DatatableContents {...this.props} results={this.props.data} />;
+
+    } else {
+
+      const {
+        className,
+        collection,
+        options,
+        showSearch,
+        showNew,
+        currentUser,
+        classes,
+      } = this.props;
+
+      const listOptions = {
+        collection: collection,
+        ...options,
+      };
+
+      const DatatableWithList = withList(listOptions)(Components.DatatableContents);
+
+      return (
+        <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
+          className)}>
+
+          {
+            showSearch &&
+
+            <Components.SearchInput value={this.state.query}
+                                    updateQuery={this.updateQuery}
+            />
+          }
+          {
+            showNew &&
+
+            <Components.NewButton collection={collection}
+                                  fab={true}
+                                  color="primary"
+                                  className={classes.addButton}
+            />
+          }
+
+
+          <DatatableWithList {...this.props}
+                             terms={{ query: this.state.query }}
+                             currentUser={currentUser}
           />
-        }
-        {
-          showNew &&
-          
-          <Components.NewButton collection={collection}
-                                variant="fab"
-                                color="primary"
-                                className={classes.addButton}
-          />
-        }
-        
-        
-        <DatatableWithList {...this.props}
-                           terms={{ query: this.state.query }}
-                           currentUser={currentUser}
-        />
-      
-      </div>
-    );
+
+        </div>
+      );
+    }
   }
 }
 
@@ -114,6 +120,7 @@ Datatable.propTypes = {
   emptyState: PropTypes.node,
   currentUser: PropTypes.object,
   classes: PropTypes.object,
+  data: PropTypes.array,
 };
 
 
@@ -154,17 +161,17 @@ const DatatableContents = ({
                              currentUser,
                              classes,
                            }) => {
-  
+
   if (loading) {
     return <Components.Loading/>;
   } else if (!results.length) {
     return emptyState || null;
   }
-  
+
   return (
     <div className="datatable-list">
       <Table className={classes.table}>
-        
+
         <TableHead className={classes.tableHead}>
           <TableRow className={classes.tableRow}>
             {
@@ -178,15 +185,15 @@ const DatatableContents = ({
             }
             {
               showEdit &&
-              
+
               <TableCell className={classes.tableCell}/>
             }
           </TableRow>
         </TableHead>
-        
+
         {
           results &&
-          
+
           <TableBody className={classes.tableBody}>
             {
               results.map(
@@ -202,9 +209,9 @@ const DatatableContents = ({
             }
           </TableBody>
         }
-      
+
       </Table>
-      
+
       <Components.LoadMore className={classes.loadMore}
                            count={count}
                            totalCount={totalCount}
@@ -225,22 +232,27 @@ DatatableHeader Component
 
 */
 const DatatableHeader = ({ collection, column, classes }, { intl }) => {
-  const schema = collection.simpleSchema()._schema;
   const columnName = typeof column === 'string' ? column : column.name;
-  
-  /*
-  use either:
-  
-  1. the column name translation
-  2. the column name label in the schema (if the column name matches a schema field)
-  3. the raw column name.
-  */
-  const formattedLabel = intl.formatMessage({
-    id: `${collection._name}.${columnName}`,
-    defaultMessage: schema[columnName] ? schema[columnName].label : columnName
-  });
-  
-  return <TableCell className={classes.tableCell}>{formattedLabel}</TableCell>;
+  if (collection) {
+    const schema = collection.simpleSchema()._schema;
+
+    /*
+    use either:
+
+    1. the column name translation
+    2. the column name label in the schema (if the column name matches a schema field)
+    3. the raw column name.
+    */
+    const formattedLabel = intl.formatMessage({
+      id: `${collection._name}.${columnName}`,
+      defaultMessage: schema[columnName] ? schema[columnName].label : columnName
+    });
+
+    return <TableCell className={classes.tableCell}>{formattedLabel}</TableCell>;
+  } else {
+    const formattedLabel = intl.formatMessage({ id: columnName, defaultMessage: columnName });
+    return <TableCell className={classes.tableCell}>{formattedLabel}</TableCell>;
+  }
 };
 
 
@@ -278,10 +290,10 @@ const DatatableRow = ({
                         currentUser,
                         classes
                       }, { intl }) => {
-  
+
   return (
     <TableRow className={classNames('datatable-item', classes.tableRow)}>
-      
+
       {
         _.sortBy(columns, column => column.order).map(
           (column, index) =>
@@ -292,10 +304,10 @@ const DatatableRow = ({
                                       classes={classes}
             />)
       }
-      
+
       {
         showEdit &&
-        
+
         <TableCell className={classes.editCell}>
           <Components.EditButton collection={collection}
                                  document={document}
@@ -303,7 +315,7 @@ const DatatableRow = ({
           />
         </TableCell>
       }
-    
+
     </TableRow>
   );
 };
@@ -343,9 +355,9 @@ const DatatableCell = ({ column, document, currentUser, classes }) => {
   const Component = column.component ||
     Components[column.componentName] ||
     Components.DatatableDefaultCell;
-  
+
   const columnName = column.name || column;
-  
+
   return (
     <TableCell
       className={classNames(classes.tableCell, `datatable-item-${columnName.toLowerCase()}`)}>


### PR DESCRIPTION
Feature created in vulcan 1.8.8: the dataTable component takes a "data" prop instead of a collection and displays it. This is used by the vulcan-debug package to display all the routes and components registered within a Vulcan app. And it's a cool feature not to relay on a collection to use the dataTable component. 
Committed here on Vulcan: https://github.com/VulcanJS/Vulcan/commit/44bff952b171fded8c1b8701f6f7559893050e77