### PR TITLE
fixed formcomponent to follow current error API

### DIFF
--- a/components/forms/FormComponent.jsx
+++ b/components/forms/FormComponent.jsx
@@ -148,9 +148,7 @@ class FormComponent extends PureComponent {
 
   */
   getErrors = () => {
-    const fieldErrors = this.props.errors.filter(
-      error => error.data.name === this.props.path
-    );
+    const fieldErrors = this.props.errors.filter(error => error.path === this.props.path);
     return fieldErrors;
   };
 

--- a/components/forms/FormErrors.jsx
+++ b/components/forms/FormErrors.jsx
@@ -29,7 +29,7 @@ const FormErrors = ({ errors, classes }) => {
           {error.message || (
             <FormattedMessage
               id={error.id}
-              values={{ ...error.data }}
+              values={{ ...error.properties }}
               defaultMessage={JSON.stringify(error)}
             />
           )}

--- a/components/forms/formsy-mui/mixins/component.js
+++ b/components/forms/formsy-mui/mixins/component.js
@@ -163,7 +163,7 @@ export default {
           errors[0].message || (
             <FormattedMessage
               id={errors[0].id}
-              values={{ ...errors[0].data }}
+              values={{ ...errors[0].properties }}
               defaultMessage={JSON.stringify(errors[0])}
             />
           )


### PR DESCRIPTION
error management changed with [this commit](https://github.com/VulcanJS/Vulcan/commit/fae7b5a03282b1e1586f5483a1f2717ed22c8cef) from error.data to error.properties when going from 1.9.0 to 1.9.1