### PR TITLE
Create theme route on dev mode only

### DIFF
--- a/modules/routes.js
+++ b/modules/routes.js
@@ -1,8 +1,10 @@
 import { addRoute } from 'meteor/vulcan:core';
 
-
-addRoute({
-  name: 'theme',
-  path: '/theme',
-  componentName: 'ThemeStyles',
-});
+//Only create route on dev mode, not production.
+if (Meteor.isDevelopment) {
+  addRoute({
+    name: 'theme',
+    path: '/theme',
+    componentName: 'ThemeStyles',
+  });
+}


### PR DESCRIPTION
It could be relevant to also remove from prod mode the code that registers the `ThemeStyles` component, what do you think about this ?