### PR TITLE
Update package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,8 +13,9 @@ Package.onUse(function (api) {
   api.use([
     'ecmascript',
     'vulcan:accounts@1.3.2',
-    'vulcan:forms@1.3.2',
-    'vulcan:core@1.3.2',
+    'vulcan:forms@1.11.2',
+    'vulcan:core@1.11.2',
+    'vulcan:ui-bootstrap@1.11.2'
   ]);
 
   api.addFiles('accounts.css', ['client', 'server']);


### PR DESCRIPTION
The current version of this package is actually dependant on `ui-boostrap`, because this package handle the first registeration of the component with `registerComponent`. Without it, `replaceComponent` will fail.

This will be fixed in Vulcan 1.11.3, which tolerate a call to `replaceComponent` even if the component does not exist yet, so that we don't need to load the package that originally registered the component.