### PR TITLE
Fix theme field name in styles

### DIFF
--- a/components/accounts/Form.jsx
+++ b/components/accounts/Form.jsx
@@ -6,7 +6,7 @@ import withStyles from '@material-ui/core/styles/withStyles';
 
 
 const styles = theme => ({
-  messages: theme.utils.errorMessages,
+  messages: theme.utils.errorMessage,
 });
 
 


### PR DESCRIPTION
errorMessages -> errorMessage

Error in theme fields name will result in `null` or `undefined` values in the styles, which in turns make Material-ui fail with obscure error `Cannot read property '@global' of undefined at handleNestedGlobalContainerRule (node_modules/jss-global/lib/index.js:125:20)`.

There might be bugs left in other components, I only tested the Accounts for the moment. Maybe material-ui `withStyles` could be encapsulated with an helper that check for null/undefined value or at least that catch errors with a clearer message?