### PR TITLE
[WIP] Fix Card

### DIFF
--- a/components/core/Card.jsx
+++ b/components/core/Card.jsx
@@ -144,11 +144,14 @@ const CardEditForm = ({ collection, document, closeModal }) =>
   />;
 
 
-const Card = ({ className, collection, document, currentUser, fields }, { intl }) => {
+const Card = ({ className, collection, document, currentUser, fields, canEdit: forceCanEdit }, { intl }) => {
   
   const fieldNames = fields ? fields : _.without(_.keys(document), '__typename');
-  const canEdit = currentUser && collection.options.mutations.edit.check(currentUser, document);
-  
+  const canEdit =
+    typeof forceCanEdit !== "undefined"
+      ? forceCanEdit
+      : currentUser &&
+        collection.options.mutations.edit.check(currentUser, document);  
   return (
     <div className={classNames(className, 'datacard', `datacard-${collection._name}`)}>
       <table className="table table-bordered" style={{ maxWidth: '100%' }}>


### PR DESCRIPTION
Fixing Card component:
- canEdit prop was ignored. You may want to force the edit button to be hidden, for example if there is an edit button somewhere else on the page.
- will add other fix if needed, please wait a little before merging