### PR TITLE
Get default columns

### DIFF
--- a/components/core/Datatable.jsx
+++ b/components/core/Datatable.jsx
@@ -88,15 +88,9 @@ class Datatable extends PureComponent {
         collection: collection,
         ...options,
       };
-<<<<<<< de50185e90810d98e3a23d98ed20df6a40ed2711
-      
+
       const DatatableWithList = withMulti(listOptions)(Components.DatatableContents);
-      
-=======
 
-      const DatatableWithList = withList(listOptions)(Components.DatatableContents);
-
->>>>>>> Fixed static datatable behaviour
       return (
         <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
           className)}>

--- a/components/core/Datatable.jsx
+++ b/components/core/Datatable.jsx
@@ -50,30 +50,30 @@ const baseStyles = theme => ({
 
 
 class Datatable extends PureComponent {
-  
-  constructor (props) {
+
+  constructor(props) {
     super(props);
-    
+
     this.updateQuery = this.updateQuery.bind(this);
-    
+
     this.state = {
       query: '',
     };
   }
-  
-  updateQuery (value) {
+
+  updateQuery(value) {
     this.setState({
       query: value,
     });
   }
-  
-  render () {
+
+  render() {
     if (this.props.data) {
-      
-      return <Components.DatatableContents {...this.props} results={this.props.data}/>;
-      
+
+      return <Components.DatatableContents columns={this.props.data.length ? Object.keys(this.props.data[0]) : undefined} {...this.props} results={this.props.data} showEdit={false} showNew={false} />;
+
     } else {
-      
+
       const {
         className,
         collection,
@@ -83,42 +83,48 @@ class Datatable extends PureComponent {
         currentUser,
         classes,
       } = this.props;
-      
+
       const listOptions = {
         collection: collection,
         ...options,
       };
+<<<<<<< de50185e90810d98e3a23d98ed20df6a40ed2711
       
       const DatatableWithList = withMulti(listOptions)(Components.DatatableContents);
       
+=======
+
+      const DatatableWithList = withList(listOptions)(Components.DatatableContents);
+
+>>>>>>> Fixed static datatable behaviour
       return (
         <div className={classNames('datatable', `datatable-${collection._name}`, classes.root,
           className)}>
-          
+
           {
             showSearch &&
-            
+
             <Components.SearchInput value={this.state.query}
-                                    updateQuery={this.updateQuery}
-                                    className={classes.search}
+              updateQuery={this.updateQuery}
+              className={classes.search}
             />
           }
           {
             showNew &&
-            
+
             <Components.NewButton collection={collection}
-                                  variant="fab"
-                                  color="primary"
-                                  className={classes.addButton}
+              variant="fab"
+              color="primary"
+              className={classes.addButton}
             />
           }
-          
-          
+
+
           <DatatableWithList {...this.props}
-                             terms={{ query: this.state.query }}
-                             currentUser={currentUser}
+            terms={{ query: this.state.query }}
+            currentUser={currentUser}
           />
-        
+
         </div>
       );
     }
@@ -174,89 +180,89 @@ const datatableContentsStyles = theme => (_assign({}, baseStyles(theme), {
 
 
 const DatatableContents = ({
-                             collection,
-                             columns,
-                             results,
-                             loading,
-                             loadMore,
-                             count,
-                             totalCount,
-                             networkStatus,
-                             refetch,
-                             showEdit,
-                             editComponent,
-                             emptyState,
-                             currentUser,
-                             classes,
-                             footerData,
-                             dense,
-                             queryDataRef,
-                             rowClass,
-                             handleRowClick,
-                             intlNamespace,
-                           }) => {
-  
+  collection,
+  columns,
+  results,
+  loading,
+  loadMore,
+  count,
+  totalCount,
+  networkStatus,
+  refetch,
+  showEdit,
+  editComponent,
+  emptyState,
+  currentUser,
+  classes,
+  footerData,
+  dense,
+  queryDataRef,
+  rowClass,
+  handleRowClick,
+  intlNamespace,
+}) => {
+
   if (loading) {
-    return <Components.Loading/>;
+    return <Components.Loading />;
   } else if (!results.length) {
     return emptyState || null;
   }
-  
+
   if (queryDataRef) queryDataRef(this.props);
-  
+
   const denseClass = dense && classes[dense + 'Table'];
-  
+
   return (
     <React.Fragment>
       <Table className={classNames(classes.table, denseClass)}>
-        
+
         <TableHead className={classes.tableHead}>
           <TableRow className={classes.tableRow}>
             {
               _.sortBy(columns, column => column.order).map(
                 (column, index) =>
                   <Components.DatatableHeader key={index}
-                                              collection={collection}
-                                              intlNamespace={intlNamespace}
-                                              column={column}
-                                              classes={classes}
+                    collection={collection}
+                    intlNamespace={intlNamespace}
+                    column={column}
+                    classes={classes}
                   />
               )
             }
             {
               (showEdit || editComponent) &&
-              
-              <TableCell className={classes.tableCell}/>
+
+              <TableCell className={classes.tableCell} />
             }
           </TableRow>
         </TableHead>
-        
+
         {
           results &&
-          
+
           <TableBody className={classes.tableBody}>
             {
               results.map(
                 (document, index) =>
                   <Components.DatatableRow collection={collection}
-                                           columns={columns}
-                                           document={document}
-                                           refetch={refetch}
-                                           key={index}
-                                           showEdit={showEdit}
-                                           editComponent={editComponent}
-                                           currentUser={currentUser}
-                                           classes={classes}
-                                           rowClass={rowClass}
-                                           handleRowClick={handleRowClick}
+                    columns={columns}
+                    document={document}
+                    refetch={refetch}
+                    key={index}
+                    showEdit={showEdit}
+                    editComponent={editComponent}
+                    currentUser={currentUser}
+                    classes={classes}
+                    rowClass={rowClass}
+                    handleRowClick={handleRowClick}
                   />)
             }
           </TableBody>
         }
-        
+
         {
           footerData &&
-          
+
           <TableFooter className={classes.tableFooter}>
             <TableRow className={classes.tableRow}>
               {
@@ -269,21 +275,21 @@ const DatatableContents = ({
               }
               {
                 (showEdit || editComponent) &&
-                
-                <TableCell className={classes.tableCell}/>
+
+                <TableCell className={classes.tableCell} />
               }
             </TableRow>
           </TableFooter>
-          
+
         }
-      
+
       </Table>
-      
+
       <Components.LoadMore className={classes.loadMore}
-                           count={count}
-                           totalCount={totalCount}
-                           loadMore={loadMore}
-                           networkStatus={networkStatus}
+        count={count}
+        totalCount={totalCount}
+        loadMore={loadMore}
+        networkStatus={networkStatus}
       />
     </React.Fragment>
   );
@@ -301,10 +307,10 @@ DatatableHeader Component
 const DatatableHeader = ({ collection, intlNamespace, column, classes }, { intl }) => {
   const columnName = typeof column === 'string' ? column : column.name;
   let formattedLabel = '';
-  
+
   if (collection) {
     const schema = collection.simpleSchema()._schema;
-    
+
     /*
     use either:
 
@@ -328,7 +334,7 @@ const DatatableHeader = ({ collection, intlNamespace, column, classes }, { intl 
   } else {
     formattedLabel = intl.formatMessage({ id: columnName, defaultMessage: columnName });
   }
-  
+
   return <TableCell className={classNames(classes.tableCell, column.headerClass)}>{formattedLabel}</TableCell>;
 };
 
@@ -359,62 +365,62 @@ const datatableRowStyles = theme => (_assign({}, baseStyles(theme), {
 
 
 const DatatableRow = ({
-                        collection,
-                        columns,
-                        document,
-                        refetch,
-                        showEdit,
-                        editComponent,
-                        currentUser,
-                        rowClass,
-                        handleRowClick,
-                        classes,
-                      }, { intl }) => {
-  
+  collection,
+  columns,
+  document,
+  refetch,
+  showEdit,
+  editComponent,
+  currentUser,
+  rowClass,
+  handleRowClick,
+  classes,
+}, { intl }) => {
+
   const EditComponent = editComponent;
-  
+
   if (typeof rowClass === 'function') {
     rowClass = rowClass(document);
   }
-  
+
   return (
     <TableRow
       className={classNames('datatable-item', classes.tableRow, rowClass, handleRowClick && classes.clickRow)}
       onClick={handleRowClick && (event => handleRowClick(event, document))}
       hover
     >
-      
+
       {
         _.sortBy(columns, column => column.order).map(
           (column, index) =>
             <Components.DatatableCell key={index}
-                                      column={column}
-                                      document={document}
-                                      currentUser={currentUser}
-                                      classes={classes}
+              column={column}
+              document={document}
+              currentUser={currentUser}
+              classes={classes}
             />)
       }
-      
+
       {
         (showEdit || editComponent) &&
-        
+
         <TableCell className={classes.editCell}>
           {
             EditComponent &&
-            
-            <EditComponent collection={collection} document={document} refetch={refetch}/>
+
+            <EditComponent collection={collection} document={document} refetch={refetch} />
           }
           {
             showEdit &&
-            
+
             <Components.EditButton collection={collection}
-                                   document={document}
-                                   buttonClasses={{ button: classes.editButton }}
+              document={document}
+              buttonClasses={{ button: classes.editButton }}
             />
           }
         </TableCell>
       }
-    
+
     </TableRow>
   );
 };
@@ -437,17 +443,17 @@ const DatatableCell = ({ column, document, currentUser, classes }) => {
   const Component = column.component ||
     Components[column.componentName] ||
     Components.DatatableDefaultCell;
-  
+
   const columnName = typeof column === 'string' ? column : column.name;
   const className = typeof columnName === 'string' ?
     `datatable-item-${columnName.toLowerCase()}` :
     '';
-  
+
   return (
     <TableCell className={classNames(classes.tableCell, className)}>
       <Component column={column}
-                 document={document}
-                 currentUser={currentUser}
+        document={document}
+        currentUser={currentUser}
       />
     </TableCell>
   );


### PR DESCRIPTION
Automatically compute the default columns for static datatables, and fix props based on Vulcan's last version.
More broadly the Vulcan implementation could be reviewed to facilitate replacing, eg by defining more registered component, right now Material UI version contains more logic than it should.
