### PR TITLE
Make theme injection customizable

### DIFF
--- a/client/wrapWithMuiTheme.jsx
+++ b/client/wrapWithMuiTheme.jsx
@@ -1,18 +1,27 @@
 import React from 'react';
-import { addCallback } from 'meteor/vulcan:core';
+import { addCallback, registerComponent, Components } from 'meteor/vulcan:core';
 import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
 import { getCurrentTheme } from '../modules/themes';
 import JssCleanup from '../components/theme/JssCleanup';
 
+class ThemeProvider extends React.Component {
+  render() {
+    const theme = getCurrentTheme();
+    return (
+      <MuiThemeProvider theme={theme}>
+        <JssCleanup>{this.props.children}</JssCleanup>
+      </MuiThemeProvider>
+    );
+  }
+}
 
-function wrapWithMuiTheme (app) {
-  const theme = getCurrentTheme();
+registerComponent('ThemeProvider', ThemeProvider);
+
+function wrapWithMuiTheme(app) {
   return (
-    <MuiThemeProvider theme={theme}>
-      <JssCleanup>
-          {app}
-      </JssCleanup>
-    </MuiThemeProvider>
+    <Components.ThemeProvider>
+      {app}
+    </Components.ThemeProvider>
   );
 }
 

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,3 +1,4 @@
 export * from './themes';
+export JssCleanup from '../components/theme/JssCleanup';
 import './sampleTheme';
 import './routes';

--- a/modules/themes.js
+++ b/modules/themes.js
@@ -40,6 +40,19 @@ export const getTheme = (name) => {
   return createMuiTheme(themeInfo.theme);
 };
 
+/**
+ * Get the raw theme object registered with registerTheme()
+ *
+ * @param {String} name The name of the theme to get
+ * 
+ * @returns {Object} The object passed to registerTheme
+ */
+
+export const getRawTheme = (name) => {
+  const themeInfo = ThemesTable[name];
+  if (!themeInfo) return null;
+  return themeInfo.theme;
+}
 
 /**
  * Get the theme specified in the 'muiTheme' setting


### PR DESCRIPTION
- The component used to wrap the app with MuiThemeProvider and JssCleanup is now registered to the Vulcan Components. This way it can be replaced. No changes have been made to how all of this works.
- I added the function `getRawTheme` that allows to get the object passed to `registerTheme` without applying `createMuiTheme` to it (which is what `getTheme` does). This way you can get the theme and overwrite it with runtime/user defined options to change some of its properties (very similar to what's on the material-ui docs site)

When this PR is merged I'll add an example for toggling between dark and light theme. Or I can add it directly to this PR if you want.