### PR TITLE
Update Datatable.jsx - missing Utils import

### DIFF
--- a/components/core/Datatable.jsx
+++ b/components/core/Datatable.jsx
@@ -5,7 +5,8 @@ import {
   registerComponent,
   replaceComponent,
   withCurrentUser,
-  withMulti
+  withMulti,
+  Utils
 } from 'meteor/vulcan:core';
 import { intlShape } from 'meteor/vulcan:i18n';
 import withStyles from '@material-ui/core/styles/withStyles';


### PR DESCRIPTION
Used @l420 : Utils.camelToSpaces(columnName)