### PR TITLE
[fix] use itemIndex prop to generate htmlFor in nested form controls

### DIFF
--- a/components/forms/base-controls/mixins/component.jsx
+++ b/components/forms/base-controls/mixins/component.jsx
@@ -51,16 +51,18 @@ export default {
    * associating the label element with the form control.
    *
    * If we don't explicitly pass an `id` prop, we generate one based on the
-   * `name` and `label` properties.
+   * `name`, `label` and `itemIndex` (for nested forms) properties.
    */
   getId: function () {
     if (this.props.id) {
       return this.props.id;
     }
     const label = (typeof this.props.label === 'undefined' ? '' : this.props.label);
+    const itemIndex = (typeof this.props.itemIndex=== 'undefined' ? '' : this.props.itemIndex);
     return [
       'frc',
       this.props.name.split('[').join('_').replace(']', ''),
+      itemIndex,
       this.hashString(JSON.stringify(label))
     ].join('-');
   },


### PR DESCRIPTION
In Nested Array controls the prop `htmlFor` and the id of the form input did not take into account the index of the array, causing labels to refer to the wrong input.
As a fix, we use the index of each nested item to generate ids in nested arrays. 